### PR TITLE
fix: enforce solvency check in claimHolderRewards (Issue #8)

### DIFF
--- a/contracts/TreasuryBTC.sol
+++ b/contracts/TreasuryBTC.sol
@@ -396,8 +396,9 @@ contract TreasuryBTC is ReentrancyGuard, Ownable {
         require(owed > 0, "Nothing to claim");
 
         uint256 available = wbtc.balanceOf(address(this));
-        uint256 toPay = owed > available ? available : owed;
-        uint256 remaining = owed - toPay;
+        require(available >= owed, "Insufficient Treasury Balance");
+        uint256 toPay = owed;
+        uint256 remaining = 0;
 
         claimedByUserGross[snapshotId][msg.sender] = gross;
         unpaidByUser[snapshotId][msg.sender] = remaining;

--- a/contracts/mocks/MockStrategy.sol
+++ b/contracts/mocks/MockStrategy.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../interfaces/IYieldStrategy.sol";
+
+contract MockStrategy is IYieldStrategy {
+    IERC20 public immutable _stablecoin;
+    address public immutable _treasury;
+
+    uint256 public totalAssetsMock;
+
+    constructor(address stablecoin_, address treasury_) {
+        _stablecoin = IERC20(stablecoin_);
+        _treasury = treasury_;
+    }
+
+    function stablecoin() external view returns (address) {
+        return address(_stablecoin);
+    }
+
+    function treasury() external view returns (address) {
+        return _treasury;
+    }
+
+    function deposit(uint256 amount) external {
+        _stablecoin.transferFrom(msg.sender, address(this), amount);
+        totalAssetsMock += amount;
+    }
+
+    function withdraw(uint256 amount) external {
+        require(totalAssetsMock >= amount, "Insufficient strategy funds");
+        totalAssetsMock -= amount;
+        _stablecoin.transfer(msg.sender, amount);
+    }
+
+    function withdrawAll() external returns (uint256) {
+        uint256 amount = totalAssetsMock;
+        totalAssetsMock = 0;
+        _stablecoin.transfer(msg.sender, amount);
+        return amount;
+    }
+
+    function harvest() external pure returns (uint256) {
+        return 0; // Simplified
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return totalAssetsMock;
+    }
+}

--- a/test/ClaimManipulation.test.js
+++ b/test/ClaimManipulation.test.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("Issue #8: TreasuryBTC Claim Manipulation", function () {
+    let NXLToken, nxl;
+    let TreasuryBTC, treasury;
+    let MockERC20, usdt, wbtc;
+    let owner, manager, user;
+
+    beforeEach(async function () {
+        [owner, manager, user] = await ethers.getSigners();
+
+        // Proven setup from IdleNXLDilution.test.js
+        MockERC20 = await ethers.getContractFactory("MockERC20Test");
+        usdt = await MockERC20.deploy("USDT", "USDT", 18);
+        wbtc = await MockERC20.deploy("WBTC", "WBTC", 8);
+        await usdt.waitForDeployment();
+        await wbtc.waitForDeployment();
+
+        NXLToken = await ethers.getContractFactory("NXLToken");
+        nxl = await NXLToken.deploy(owner.address, owner.address); // Adjusted if necessary
+        await nxl.waitForDeployment();
+
+        // NXL Setup
+        await nxl.setNexumManager(manager.address);
+
+        TreasuryBTC = await ethers.getContractFactory("TreasuryBTC");
+        const redeemStart = (await time.latest()) + 86400;
+        treasury = await TreasuryBTC.deploy(
+            await usdt.getAddress(),
+            await nxl.getAddress(),
+            manager.address,
+            await wbtc.getAddress(),
+            redeemStart,
+            7 * 86400
+        );
+        await treasury.waitForDeployment();
+
+        await nxl.connect(manager).setTreasuryBTC(await treasury.getAddress());
+
+        // 4. Setup Initial State for Issue 8
+        // Distribute NXL to User
+        const nxlAmount = ethers.parseEther("1000");
+        await nxl.connect(manager).distributeReward(user.address, nxlAmount);
+
+        // Fund Treasury with WBTC
+        const wbtcAmount = ethers.parseUnits("10", 8);
+        await wbtc.mint(await treasury.getAddress(), wbtcAmount);
+
+        // Create Snapshot & Allocate
+        // This reserves 10 WBTC.
+        await treasury.snapshotAndAllocateHolderRewards(wbtcAmount);
+    });
+
+    it("should REVERT when balance is insufficient (Fix Verified)", async function () {
+        const snapshotId = 1;
+
+        // ATTACK: Simulate manipulation of balance (Burn/Loss).
+        await wbtc.burn(await treasury.getAddress(), ethers.parseUnits("10", 8));
+        expect(await wbtc.balanceOf(await treasury.getAddress())).to.equal(0);
+
+        // Action: User Claims
+        // Expect Revert due to fix
+        await expect(treasury.connect(user).claimHolderRewards(snapshotId))
+            .to.be.revertedWith("Insufficient Treasury Balance");
+
+        console.log("Fix Verified: Transaction reverted when safe liquidity was missing.");
+    });
+});


### PR DESCRIPTION
Fixes #8

## Description
This PR addresses the critical vulnerability in `TreasuryBTC::claimHolderRewards` where claims could be processed even when the contract had insufficient WBTC balance (due to manipulation, insolvency, or accounting desyncs).

**Vulnerability:**
Previously, the contract used a "best effort" approach:
```solidity
uint256 available = wbtc.balanceOf(address(this));
uint256 toPay = owed > available ? available : owed; // If available == 0, toPay == 0
```
This allowed transactions to succeed with 0 payment, effectively treating the claim as "processed" (moving the debt to `unpaid` but ensuring the user received nothing for their gas). In a worst-case scenario involving manipulation of `balanceOf`, users could be griefed.

**Fix:**
Enforced a solvency check:
```solidity
require(available >= owed, "Insufficient Treasury Balance");
```
The transaction now reverts if the Treasury cannot fully cover the specific claim, protecting the user from silent failure and signaling the insolvency clearly.

## Verification
Added `test/ClaimManipulation.test.js` to simulate low-balance scenarios.
- **Before Fix**: Transaction succeeded with 0 value transferred.
- **After Fix**: Transaction reverts with "Insufficient Treasury Balance".

## Checklist
- [x] Fix applied to `TreasuryBTC.sol`
- [x] Reproduction test added
- [x] Verified revert behavior conforms to safety standards

CC: @vendrell46
